### PR TITLE
Fix equality check between tuples in JS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,10 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.1.2"
-          gleam-version: "1.6.1"
+          gleam-version: "1.9.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download
-      - run: gleam test
+      - run: gleam test --target=erlang
+      - run: gleam test --target=js
       - run: gleam format --check src test

--- a/src/bright.ffi.mjs
+++ b/src/bright.ffi.mjs
@@ -25,6 +25,6 @@ function areTupleMembersReferentiallyEquals(a, b) {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i++)
     // Referential equality.
-    if (a[0] !== b[0]) return false
+    if (a[i] !== b[i]) return false
   return true
 }

--- a/test/bright_test.gleam
+++ b/test/bright_test.gleam
@@ -1,3 +1,4 @@
+import gleam/dynamic
 import gleeunit
 import gleeunit/should
 
@@ -5,8 +6,84 @@ pub fn main() {
   gleeunit.main()
 }
 
+@external(javascript, "./bright.ffi.mjs", "areDependenciesEqual")
+fn are_dependencies_equal(a: a, b: b) -> Bool {
+  dynamic.from(a) == dynamic.from(b)
+}
+
 // gleeunit test functions end in `_test`
-pub fn hello_world_test() {
-  1
-  |> should.equal(1)
+pub fn int_equal_test() {
+  let a = 1
+  are_dependencies_equal(a, a) |> should.equal(True)
+  are_dependencies_equal(a, 1) |> should.equal(True)
+  are_dependencies_equal(a, 2) |> should.equal(False)
+}
+
+pub fn tuple_equal_test() {
+  let a = #(2, 3)
+  are_dependencies_equal(a, a) |> should.equal(True)
+  are_dependencies_equal(a, #(2, 3)) |> should.equal(True)
+  are_dependencies_equal(a, #(2, 5)) |> should.equal(False)
+  are_dependencies_equal(a, #(2, 3, 4)) |> should.equal(False)
+  are_dependencies_equal(a, #(3, 2)) |> should.equal(False)
+  are_dependencies_equal(a, #(2, 4)) |> should.equal(False)
+}
+
+pub fn list_equal_test() {
+  let a = [1, 2, 3]
+  are_dependencies_equal(a, a) |> should.equal(True)
+  are_dependencies_equal(a, [1, 2, 3]) |> should.equal(True)
+  are_dependencies_equal(a, [1, 2, 0]) |> should.equal(False)
+  are_dependencies_equal(a, [0, 2, 3]) |> should.equal(False)
+  are_dependencies_equal(a, [1, 2]) |> should.equal(False)
+  are_dependencies_equal(a, [1, 2, 3, 4]) |> should.equal(False)
+  are_dependencies_equal(a, [1, 3, 2]) |> should.equal(False)
+  are_dependencies_equal(a, []) |> should.equal(False)
+}
+
+pub fn nested_equal_test() {
+  let a = [#(1, 2), #(3, 4), #(5, 6)]
+  are_dependencies_equal(a, a) |> should.equal(True)
+  are_dependencies_equal(a, [#(1, 2), #(3, 4), #(5, 6)]) |> should.equal(True)
+  are_dependencies_equal(a, [#(1, 0), #(3, 4), #(5, 6)]) |> should.equal(False)
+  are_dependencies_equal(a, [#(1, 2), #(3, 4), #(5, 0)]) |> should.equal(False)
+  are_dependencies_equal(a, [#(1, 2), #(3, 4)]) |> should.equal(False)
+  are_dependencies_equal(a, [#(1, 2), #(3, 4), #(5, 6), #(7, 8)])
+  |> should.equal(False)
+  are_dependencies_equal(a, []) |> should.equal(False)
+}
+
+pub type DummyTree(a) {
+  Leaf
+  Node(value: a, left: DummyTree(a), right: DummyTree(a))
+}
+
+pub fn tree_equal_test() {
+  let a =
+    Node(
+      5,
+      Node(3, Leaf, Leaf),
+      Node(7, Leaf, Node(9, Node(8, Leaf, Leaf), Leaf)),
+    )
+  are_dependencies_equal(a, a) |> should.equal(True)
+  are_dependencies_equal(
+    a,
+    Node(
+      5,
+      Node(3, Leaf, Leaf),
+      Node(7, Leaf, Node(9, Node(8, Leaf, Leaf), Leaf)),
+    ),
+  )
+  |> should.equal(True)
+  are_dependencies_equal(a, Node(5, Node(3, Leaf, Leaf), Node(7, Leaf, Leaf)))
+  |> should.equal(False)
+  are_dependencies_equal(
+    a,
+    Node(
+      5,
+      Node(7, Leaf, Node(9, Node(8, Leaf, Leaf), Leaf)),
+      Node(3, Leaf, Leaf),
+    ),
+  )
+  |> should.equal(False)
 }


### PR DESCRIPTION
Issue: The equality check between tuples in JS only checked if the first elements of the tuples were different. 
Fix: It now checks that every elements of the two tuples are equal between the tuples.  

Also added tests for this equality check.  
Also added a github action running tests with JS target. 
